### PR TITLE
Issue #919: Minimum RAM Requirements

### DIFF
--- a/bin/sosetup
+++ b/bin/sosetup
@@ -226,14 +226,13 @@ fi
 if [ $ADVANCED_SETUP -eq 0 ]; then
 	[ $DEBUG -eq 1 ] && echo "DEBUG: Selected Evaluation Mode."
 	if [ $TOTAL_MEM -lt 3000 ]; then zenity --question --title="$TITLE" --text="$MEM_TEXT" --ok-label="$YES" --cancel-label="$NO" --no-wrap 
-#[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
-			if [ $? = 1 ]; then
-				if [ $DEBUG -eq 1 ]; then
-					echo "DEBUG: Clicked No.  Exiting." && exit 1
-						else
-					exit 1
-				fi
+		if [ $? = 1 ]; then
+			if [ $DEBUG -eq 1 ]; then
+				echo "DEBUG: Clicked No.  Exiting." && exit 1
+			else
+				exit 1
 			fi
+		fi
 	[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
 	fi
         if [ $NUM_INTERFACES -gt 1 ]; then

--- a/bin/sosetup
+++ b/bin/sosetup
@@ -124,6 +124,14 @@ ELSA="YES"
 mkdir -p /nsm
 # Calculate half of available disk space for ELSA log_size_limit
 DISK_SIZE_K=`df /nsm |grep -v "^Filesystem" | awk '{print $2}'`
+# Check amount of system RAM (MB)
+TOTAL_MEM=`grep MemTotal /proc/meminfo | awk '{print $2}' | sed -r 's/.{3}$//'`
+# Make RAM # human readable (GB)
+HR_MEM=$((TOTAL_MEM / 1000))
+# Text for minimum memory check
+MEM_TEXT="This machine currently has "$HR_MEM"GB of RAM allocated.\n\For best performance, please ensure the machine is allocated at least 3GB of RAM.\n\n\Please consult the following link for more information:\n\https://github.com/Security-Onion-Solutions/security-onion/wiki/Hardware\n\n\
+Click 'No' to stop setup and adjust the amount oF RAM allocated to this machine.\n\
+Otherwise, click 'Yes' to continue."
 let DISK_SIZE=DISK_SIZE_K*1000
 let LOG_SIZE_LIMIT=DISK_SIZE/2
 let LOG_SIZE_LIMIT_GB=LOG_SIZE_LIMIT/1000000000
@@ -217,7 +225,17 @@ fi
 [ "$SETUP" == "Production Mode" ] && ADVANCED_SETUP="1" || ADVANCED_SETUP="0"
 if [ $ADVANCED_SETUP -eq 0 ]; then
 	[ $DEBUG -eq 1 ] && echo "DEBUG: Selected Evaluation Mode."
-
+	if [ $TOTAL_MEM -lt 3000 ]; then zenity --question --title="$TITLE" --text="$MEM_TEXT" --ok-label="$YES" --cancel-label="$NO" --no-wrap 
+#[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
+			if [ $? = 1 ]; then
+				if [ $DEBUG -eq 1 ]; then
+					echo "DEBUG: Clicked No.  Exiting." && exit 1
+						else
+					exit 1
+				fi
+			fi
+	[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
+	fi
         if [ $NUM_INTERFACES -gt 1 ]; then
                 TEXT="Which network interface should be monitored?\n\nIf you allowed Setup to configure /etc/network/interfaces, your first monitor interface is already selected."
                 INTERFACES=`cat "/proc/net/dev" | egrep "(eth|bond|wlan|br|ath|bge|mon|fe|em|p[0-5]p)[0-9]+" | awk '{print $1}' | cut -d\: -f1 | sort`
@@ -241,7 +259,6 @@ if [ $ADVANCED_SETUP -eq 0 ]; then
                 fi
                 [ $DEBUG -eq 1 ] &&  echo "DEBUG: Selected interfaces $INTERFACES."
         fi
-
 	SERVER=1
 	SENSOR=1
         ELSA="YES"
@@ -262,10 +279,20 @@ Otherwise, choose Standalone to configure both Server and Sensor components on t
 	COMPONENTS=`zenity --height=300 --list --radiolist --column="1" --column="2" --hide-header --title="$TITLE" --text="$TEXT" TRUE Server FALSE Sensor FALSE Standalone`
 	case $COMPONENTS in
         Standalone)
-                [ $DEBUG -eq 1 ] && echo "DEBUG: Selected Standalone"
+                [ $DEBUG -eq 1 ] && echo "DEBUG: Selected Standalone."
 		SERVER=1
 		SENSOR=1
 		SERVERNAME="localhost"
+		if [ $TOTAL_MEM -lt 3000 ];then zenity --question --title="$TITLE" --text="$MEM_TEXT" --ok-label="$YES" --cancel-label="$NO" --no-wrap
+			if [ $? = 1 ]; then
+				if [ $DEBUG -eq 1 ]; then
+					echo "DEBUG: Clicked No.  Exiting." && exit 1
+				else
+					exit 1
+				fi
+			fi
+		[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
+		fi
 		;;
 	Server)
                 [ $DEBUG -eq 1 ] && echo "DEBUG: Selected Server."
@@ -274,6 +301,18 @@ Otherwise, choose Standalone to configure both Server and Sensor components on t
 		SERVERNAME="localhost"
 		IDS_LB_PROCS_CONFIRM=""
 		BRO_LB_PROCS_CONFIRM=""
+		if [ $TOTAL_MEM -lt 2000 ];then zenity --question --title="$TITLE" --text="This machine currently has "$HR_MEM"GB of RAM allocated.\n\For best performance, please ensure the machine is allocated at least 3GB of RAM.\n\n\Consult the following link for more information:\n\https://github.com/Security-Onion-Solutions/security-onion/wiki/Hardware\n\n\
+Click 'No' to stop setup and adjust the amount oF RAM allocated to this machine.\n\
+Otherwise, click 'Yes' to continue." --ok-label="$YES" --cancel-label="$NO" --no-wrap
+			if [ $? = 1 ]; then
+				if [ $DEBUG -eq 1 ]; then
+					echo "DEBUG: Clicked No.  Exiting." && exit 1
+				else
+					exit 1
+				fi
+			fi
+		[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
+		fi
 		;;
 	Sensor)
                 [ $DEBUG -eq 1 ] && echo "DEBUG: Selected Sensor."
@@ -281,6 +320,16 @@ Otherwise, choose Standalone to configure both Server and Sensor components on t
 		SENSOR=1
 		TEXT="What is the hostname or IP address of the master server that this sensor should connect to?"
 		SERVERNAME_CONFIRMED="no"
+		if [ $TOTAL_MEM -lt 3000 ];then zenity --question --title="$TITLE" --text="$MEM_TEXT" --ok-label="$YES" --cancel-label="$NO" --no-wrap
+			if [ $? = 1 ]; then
+				if [ $DEBUG -eq 1 ]; then
+					echo "DEBUG: Clicked No.  Exiting." && exit 1
+				else
+					exit 1
+				fi
+			fi
+		[ $DEBUG -eq 1 ] && echo "DEBUG: Continuing, despite low RAM."
+		fi
 		while [ $SERVERNAME_CONFIRMED = "no" ]; do
 			SERVERNAME=`zenity --title="$TITLE" --text="$TEXT" --entry`
 			if [ $? = 1 ]; then


### PR DESCRIPTION
In reference to Issue #919.

If allocated RAM is not at least the following, a prompt will appear after deployment type selection.

Evaluation Mode --> 3GB
Production Mode:
Server --> 2GB
Sensor --> 3GB
Standalone --> 3GB

Recommendation will be made to increase RAM before running setup, but user will be provided option to continue anyway.