### PR TITLE
Setup: ask user for MTU of sniffing interface(s) and allow VLAN tags

### DIFF
--- a/bin/sosetup
+++ b/bin/sosetup
@@ -45,6 +45,8 @@ ALL_INTERFACES="$INTERFACES"
 NUM_INTERFACES=`echo $INTERFACES | wc -w`
 SNIFF_INTERFACES=`awk '/manual/ {print $2}' /etc/network/interfaces | wc -l`
 [ $SNIFF_INTERFACES -eq 0 ] && SNIFF_INTERFACES=1
+MTU=`cat "/etc/network/interfaces" | egrep "mtu" | awk '{print $2;exit}'`
+MTU_FIN=`echo $(($MTU+16))`
 SENSORTAB="/etc/nsm/sensortab"
 UPDATE_ELSA_SERVER="NO"
 # PCAP_OPTIONS are passed to netsniff-ng
@@ -1315,6 +1317,7 @@ for INTERFACE in $ALL_INTERFACES; do
         cp /etc/nsm/templates/snort/snort.conf /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/snort/unicode.map /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/suricata/suricata.yaml.in /etc/nsm/"$SENSORNAME"/suricata.yaml >> $LOG 2>&1
+	sed -i "s|# config snaplen:|config snaplen: $MTU_FIN|g" /etc/nsm/"$SENSORNAME"/snort.conf
 	sed -i "s|classification-file: /etc/suricata/classification.config|classification-file: /etc/nsm/$SENSORNAME/classification.config|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	sed -i "s|reference-config-file: /etc/suricata/reference.config|reference-config-file: /etc/nsm/$SENSORNAME/reference.config|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	sed -i "s|# threshold-file: /etc/suricata/threshold.config|threshold-file: /etc/nsm/$SENSORNAME/threshold.conf|g" /etc/nsm/"$SENSORNAME"/suricata.yaml

--- a/bin/sosetup-network
+++ b/bin/sosetup-network
@@ -315,14 +315,24 @@ if [ $NUM_MON_INTERFACES -gt 0 ]; then
 		fi
 		SNIFF_TEXT="    - Configure the following interface(s) for sniffing:\n\
                 $MON_INTERFACES"
-		TEXT="What is the default MTU of your network?\n\n\Most networks use an MTU of 1500, however, Security Onion will configure a default\n\MTU of 1550, in order to allow for Q-in-Q, MPLS, and VLAN-tagged traffic.\n\\n\Please note, Snort and Suricata will add 16 to whatever value you set here\n\and use the resulting value for snaplen."
-		MTU=`zenity --title="$TITLE" --text="$TEXT" --entry --entry-text="1550"`
-		ANSWER="$?"
-		if [ $ANSWER -eq 1 ]; then
-			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
-		else
-			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring MTU as $MTU."
-		fi
+		# Configure default MTU for sniffing interface(s)
+                VALID="no"
+                while [ $VALID = "no" ]; do
+                        TEXT="What is the default MTU of your network?\n\n\Most networks use an MTU of 1500, however, Security Onion will configure a default\n\MTU of 1550, in order to allow for Q-in-Q, MPLS, and VLAN-tagged traffic.\n\\n\Please note, Snort and Suricata will add 16 to whatever value you set here\n\and use the resulting value for snaplen."
+                        MTU=`zenity --title="$TITLE" --text="$TEXT" --entry --entry-text="1550"`
+                        ANSWER="$?"
+                        if [ $ANSWER -eq 1 ]; then
+                                [ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
+                                exit 1
+                        else
+                                if [ "$MTU" = "" ]; then
+                                        zenity --error --text="Please enter a value for the MTU!"
+                                else
+                                        VALID="yes"
+                                        [ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring MTU as $MTU."
+                                fi
+                        fi
+                done
 	fi
    fi
 fi

--- a/bin/sosetup-network
+++ b/bin/sosetup-network
@@ -315,6 +315,14 @@ if [ $NUM_MON_INTERFACES -gt 0 ]; then
 		fi
 		SNIFF_TEXT="    - Configure the following interface(s) for sniffing:\n\
                 $MON_INTERFACES"
+		TEXT="What is the default MTU of your network?\n\n\Most networks use an MTU of 1500, however, Security Onion will configure a default\n\MTU of 1550, in order to allow for Q-in-Q, MPLS, and VLAN-tagged traffic.\n\\n\Please note, Snort and Suricata will add 16 to whatever value you set here\n\and use the resulting value for snaplen."
+		MTU=`zenity --title="$TITLE" --text="$TEXT" --entry --entry-text="1550"`
+		ANSWER="$?"
+		if [ $ANSWER -eq 1 ]; then
+			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
+		else
+			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring MTU as $MTU."
+		fi
 	fi
    fi
 fi
@@ -410,8 +418,8 @@ fi
 for INTERFACE in $MON_INTERFACES
 do
             	# Get max RX size for monitored interface
-            	MAX_RX=$(ethtool -g $INTERFACE | grep -m 1 RX | cut -d\: -f2 | awk '{sub(/^[ \t]+/, "")};1')
-    
+		MAX_RX=$(ethtool -g $INTERFACE | grep -m 1 RX | cut -d\: -f2 | awk '{sub(/^[ \t]+/, "")};1')
+
 cat << EOF >> $FILE
 auto $INTERFACE
 iface $INTERFACE inet manual
@@ -419,7 +427,7 @@ iface $INTERFACE inet manual
   down ip link set \$IFACE promisc off down
   post-up ethtool -G \$IFACE rx $MAX_RX; for i in rx tx sg tso ufo gso gro lro; do ethtool -K \$IFACE \$i off; done
   post-up echo 1 > /proc/sys/net/ipv6/conf/\$IFACE/disable_ipv6
-
+  mtu $MTU
 EOF
 
 done

--- a/bin/sosetup-network
+++ b/bin/sosetup-network
@@ -325,14 +325,19 @@ if [ $NUM_MON_INTERFACES -gt 0 ]; then
                                 [ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
                                 exit 1
                         else
-                                if [ "$MTU" = "" ]; then
-                                        zenity --error --text="Please enter a value for the MTU!"
-                                else
-                                        VALID="yes"
-                                        [ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring MTU as $MTU."
-					MTU_TEXT="    - Configure the MTU for the sniffing interface(s):\n\		$MTU"
+                                if echo $MTU | egrep '^[0-9]+$' >/dev/null 2>&1
+				then
+					if [[ "$MTU" -ge "1" ]] && [[ "$MTU" -le "65000" ]]; then
+						VALID="yes"
+						[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring MTU as $MTU."
+						MTU_TEXT="    - Configure the MTU for the sniffing interface(s):\n\                $MTU"
+					else
+						zenity --error --text="Please provide an integer value between 1 and 65000!"
+					fi
+				else
+					zenity --error --text="Not a number -- please use integers only!"
 				fi
-                        fi
+			fi
                 done
 	fi
    fi

--- a/bin/sosetup-network
+++ b/bin/sosetup-network
@@ -330,7 +330,8 @@ if [ $NUM_MON_INTERFACES -gt 0 ]; then
                                 else
                                         VALID="yes"
                                         [ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring MTU as $MTU."
-                                fi
+					MTU_TEXT="    - Configure the MTU for the sniffing interface(s):\n\		$MTU"
+				fi
                         fi
                 done
 	fi
@@ -343,6 +344,7 @@ TEXT="We're about to do the following:\n\
     - Backup existing network configuration to /etc/network/interfaces.bak \n\
     - $MANAGEMENT_TEXT \n\
 $SNIFF_TEXT \n\
+$MTU_TEXT
     \n\
     We're about to make changes to your system! \n\
     \n\


### PR DESCRIPTION
#925 
sosetup-network now defaults to an MTU size of 1550 to allow for Q-in-Q, MPLS, VLAN-tagged traffic.  Snort and Suricata will add 16 to this value, and to any MTU value the user specifies.