### PR TITLE
sosetup: ask user for HOME_NET

### DIFF
--- a/bin/sosetup
+++ b/bin/sosetup
@@ -391,7 +391,6 @@ Please provide a username that can SSH to the master server and execute sudo."
                 exit
                 ;;
         esac
-
 	TEXT="Best Practices or Custom?\n\
 \n\
 If you'd like to use the Best Practices defaults, please select Best Practices.\n\
@@ -614,7 +613,6 @@ if [ $ADVANCED_SETUP -eq 1 ] && [ $SENSOR -eq 1 ]; then
 			PF_RING_SLOTS_CONFIRMED="yes"
 		fi
 	done
-
 	# Ask which interface(s) to listen on
 	if [ $NUM_INTERFACES -gt 1 ]; then
 	TEXT="Which network interface(s) should be monitored?\n\nIf you allowed Setup to configure /etc/network/interfaces, your monitor interfaces are already selected."
@@ -664,7 +662,6 @@ Would you like to enable the IDS Engine?"
 			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Yes.  Enabling IDS Engine."
 		fi
 	fi
-
 	# IDS Engine Procs
         if [ "$IDS_ENGINE_ENABLED" == "yes" ] && [ "$CALCD_CORES" -gt 1 ] && [ "$CUSTOM" -eq 1 ]; then
                 TEXT="How many IDS engine processes would you like to run?\n\
@@ -691,6 +688,38 @@ If you need to change this setting later, change IDS_LB_PROCS in /etc/nsm/HOSTNA
 			IDS_LB_PROCS=1
 			IDS_LB_PROCS_CONFIRM="- Run a single IDS engine process per interface.\n"
                 fi
+	fi
+	# Ask if user would like to configure a custom HOME_NET
+	if [ "$IDS_ENGINE_ENABLED" == "yes" ]; then
+		TEXT="Would you like to specify a custom HOME_NET?\n\\n\Snort/Suricata uses the HOME_NET variable to determine (usually local network) IP addresses to protect.\n\n\The default HOME_NET is configured as the following (RFC 1918):\n\\n\ 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
+		YES="Yes, configure a custom HOME__NET."
+		NO="No, use the default HOME__NET."
+		zenity --question --title="$TITLE" --text="$TEXT" --ok-label="$YES" --cancel-label="$NO" --no-wrap
+		ANSWER="$?"
+		if [ $ANSWER -eq 1 ]; then
+			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked No.  Configuring default RFC 1918 HOME_NET."
+			HOME_NET="192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
+		else
+			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Yes.  Configuring custom HOME_NET."
+			HOME_NET_CONFIRMED="no"
+			while [ "$HOME_NET_CONFIRMED" == "no" ];do
+				TEXT="What would you like to configure HOME__NET as?\n\n\Add a comma (no space) after each address range.\n\n\Ex. 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
+				HOME_NET=`zenity --title="$TITLE" --text="$TEXT" --entry`
+				ANSWER="$?"
+				if [ $ANSWER -eq 1 ]; then
+					[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
+					exit 1
+				else
+					if [ "$HOME_NET" == "" ]; then
+						zenity --error --title "$TITLE" --text="Please provide a value for HOME_NET!"
+					else
+						HOME_NET_CONFIRMED="yes"
+						[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring HOME_NET as $HOME_NET."
+					fi
+				fi
+			done
+		fi
+		IDS_HOME_NET_CONFIRM="- Configure IDS HOME_NET as: $HOME_NET.\n"
 	fi
 	if [ $CUSTOM -eq 1 ]; then
 	# Bro
@@ -1065,6 +1094,7 @@ $SENSOR_CONFIRM_3\
 $IDS_LB_PROCS_CONFIRM\
 $BRO_LB_PROCS_CONFIRM\
 $IDS_RULESET_ACTION\
+$IDS_HOME_NET_CONFIRM\
 $ELSA_ACTION_CONFIRM\
 \n\
 We're about to make changes to your system!\n\
@@ -1315,6 +1345,7 @@ for INTERFACE in $ALL_INTERFACES; do
         cp /etc/nsm/templates/snort/snort.conf /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/snort/unicode.map /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/suricata/suricata.yaml.in /etc/nsm/"$SENSORNAME"/suricata.yaml >> $LOG 2>&1
+	sed -i "s|^ipvar HOME_NET.*|ipvar HOME_NET \[$HOME_NET\]|g" /etc/nsm/"$SENSORNAME"/snort.conf
 	sed -i "s|classification-file: /etc/suricata/classification.config|classification-file: /etc/nsm/$SENSORNAME/classification.config|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	sed -i "s|reference-config-file: /etc/suricata/reference.config|reference-config-file: /etc/nsm/$SENSORNAME/reference.config|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	sed -i "s|# threshold-file: /etc/suricata/threshold.config|threshold-file: /etc/nsm/$SENSORNAME/threshold.conf|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
@@ -1322,6 +1353,7 @@ for INTERFACE in $ALL_INTERFACES; do
 	#sed -i "s|threads: 1|threads: $IDS_LB_PROCS|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	sed -i "s|interface: eth0|interface: $INTERFACE|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	sed -i "s|cluster-id: 99|cluster-id: $BY2PORT|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
+	sed -i "s|HOME_NET:.*|HOME_NET: \"[$HOME_NET]\"|g" /etc/nsm/"$SENSORNAME"/suricata.yaml
 	mkdir -p /usr/local/lib/snort_dynamicrules
 
 	# /etc/nsm/rules/

--- a/bin/sosetup
+++ b/bin/sosetup
@@ -40,6 +40,7 @@ VRT_URL="www.snort.org"
 SGUIL_SERVER_NAME="securityonion"
 IDS_ENGINE="snort"
 IDS_RULESET="ETGPL"
+HOME_NET="192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
 INTERFACES=`cat "/proc/net/dev" | egrep "(eth|bond|wlan|br|ath|bge|mon|fe|em|p[0-5]p)[0-9]+" | awk '{print $1}' | cut -d\: -f1 |sort`
 ALL_INTERFACES="$INTERFACES"
 NUM_INTERFACES=`echo $INTERFACES | wc -w`
@@ -691,36 +692,25 @@ If you need to change this setting later, change IDS_LB_PROCS in /etc/nsm/HOSTNA
 	fi
 	# Ask if user would like to configure a custom HOME_NET
 	if [ "$IDS_ENGINE_ENABLED" == "yes" ]; then
-		TEXT="Would you like to specify a custom HOME_NET?\n\\n\Snort/Suricata uses the HOME_NET variable to determine (usually local network) IP addresses to protect.\n\n\The default HOME_NET is configured as the following (RFC 1918):\n\\n\ 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
-		YES="Yes, configure a custom HOME__NET."
-		NO="No, use the default HOME__NET."
-		zenity --question --title="$TITLE" --text="$TEXT" --ok-label="$YES" --cancel-label="$NO" --no-wrap
-		ANSWER="$?"
-		if [ $ANSWER -eq 1 ]; then
-			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked No.  Configuring default RFC 1918 HOME_NET."
-			HOME_NET="192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
-		else
-			[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Yes.  Configuring custom HOME_NET."
-			HOME_NET_CONFIRMED="no"
-			while [ "$HOME_NET_CONFIRMED" == "no" ];do
-				TEXT="What would you like to configure HOME__NET as?\n\n\Add a comma (no space) after each address range.\n\n\Ex. 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
-				HOME_NET=`zenity --title="$TITLE" --text="$TEXT" --entry`
-				ANSWER="$?"
-				if [ $ANSWER -eq 1 ]; then
-					[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
-					exit 1
+		HOME_NET_CONFIRMED="no"
+		while [ "$HOME_NET_CONFIRMED" == "no" ];do
+			TEXT="What would you like to configure HOME__NET as?\n\n\Add a comma (no space) after each address range.\n\n\Ex. 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
+			HOME_NET=`zenity --title="$TITLE" --text="$TEXT" --entry --entry-text="$HOME_NET"`
+			ANSWER="$?"
+			if [ $ANSWER -eq 1 ]; then
+				[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked Cancel.  Exiting Setup."
+				exit 1
+			else
+				if [ "$HOME_NET" == "" ]; then
+					zenity --error --title "$TITLE" --text="Please provide a value for HOME_NET!"
 				else
-					if [ "$HOME_NET" == "" ]; then
-						zenity --error --title "$TITLE" --text="Please provide a value for HOME_NET!"
-					else
-						HOME_NET_CONFIRMED="yes"
-						[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring HOME_NET as $HOME_NET."
-					fi
+					HOME_NET_CONFIRMED="yes"
+					[ $DEBUG -eq 1 ] && echo "DEBUG: Clicked OK.  Configuring HOME_NET as $HOME_NET."
 				fi
-			done
-		fi
-		IDS_HOME_NET_CONFIRM="- Configure IDS HOME_NET as: $HOME_NET.\n"
+			fi
+		done
 	fi
+	IDS_HOME_NET_CONFIRM="- Configure IDS HOME_NET as: $HOME_NET.\n"
 	if [ $CUSTOM -eq 1 ]; then
 	# Bro
 	TEXT="Bro listens on the chosen interfaces and writes protocol logs.\n\
@@ -1499,11 +1489,8 @@ EOF
         fi
 	# Finished with node.cfg
 	# Now update networks.cfg
-	if grep "172.16" /opt/bro/etc/networks.cfg >/dev/null; then
-		echo "/opt/bro/etc/networks.cfg already contains 172.16" >> $LOG 2>&1
-	else
-		echo "172.16.0.0/12       Private IP space" >> /opt/bro/etc/networks.cfg
-	fi
+	sed -i '1,4!d' /opt/bro/etc/networks.cfg
+	echo $HOME_NET | tr , '\n\\' >> /opt/bro/etc/networks.cfg
 	# update broctl.cfg
 	if grep "nsm" /opt/bro/etc/broctl.cfg >/dev/null; then
 		echo "/opt/bro/etc/broctl.cfg already contains nsm" >> $LOG 2>&1

--- a/share/securityonion/sosetup.conf
+++ b/share/securityonion/sosetup.conf
@@ -273,6 +273,14 @@ IDS_ENGINE='snort'
 # This value should be lower than your number of CPU cores.
 IDS_LB_PROCS='1'
 
+# HOME_NET
+# Setup by default configures Snort/Suricata's HOME_NET variable
+# as RFC 1918 (192.168.0.0/16,10.0.0.0/8,172.16.0.0/12).
+# If you wish to provide a custom value, enter it below,
+# ensuring a comma is placed after each range, with no spaces in between.
+# Ex. HOME_NET='192.168.0.0/16,10.0.0.0/8,172.16.0.0/12'
+HOME_NET='192.168.0.0/16,10.0.0.0/8,172.16.0.0/12'
+
 ################################
 # Bro Config
 ################################


### PR DESCRIPTION
- Allows user to choose default RFC 1918 HOME_NET (Snort/Suricata), or define their own.
- Applies to sensor and standalone machines.

Setup: ask user for HOME_NET #926