### PR TITLE
sosetup: fix MTU for when user does not re-run sosetup-network

### DIFF
--- a/bin/sosetup
+++ b/bin/sosetup
@@ -47,6 +47,10 @@ NUM_INTERFACES=`echo $INTERFACES | wc -w`
 SNIFF_INTERFACES=`awk '/manual/ {print $2}' /etc/network/interfaces | wc -l`
 [ $SNIFF_INTERFACES -eq 0 ] && SNIFF_INTERFACES=1
 MTU=`cat "/etc/network/interfaces" | egrep "mtu" | awk '{print $2;exit}'`
+if [ -z "$MTU" ];then
+	sed -i '/.*post-up echo.*/ a \  mtu 1550' /etc/network/interfaces
+	MTU="1550"
+fi
 MTU_FIN=`echo $(($MTU+16))`
 SENSORTAB="/etc/nsm/sensortab"
 UPDATE_ELSA_SERVER="NO"

--- a/bin/sosetup
+++ b/bin/sosetup
@@ -46,12 +46,6 @@ ALL_INTERFACES="$INTERFACES"
 NUM_INTERFACES=`echo $INTERFACES | wc -w`
 SNIFF_INTERFACES=`awk '/manual/ {print $2}' /etc/network/interfaces | wc -l`
 [ $SNIFF_INTERFACES -eq 0 ] && SNIFF_INTERFACES=1
-MTU=`cat "/etc/network/interfaces" | egrep "mtu" | awk '{print $2;exit}'`
-if [ -z "$MTU" ];then
-	sed -i '/.*post-up echo.*/ a \  mtu 1550' /etc/network/interfaces
-	MTU="1550"
-fi
-MTU_FIN=`echo $(($MTU+16))`
 SENSORTAB="/etc/nsm/sensortab"
 UPDATE_ELSA_SERVER="NO"
 # PCAP_OPTIONS are passed to netsniff-ng
@@ -1344,6 +1338,12 @@ for INTERFACE in $ALL_INTERFACES; do
         cp /etc/nsm/templates/snort/snort.conf /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/snort/unicode.map /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/suricata/suricata.yaml.in /etc/nsm/"$SENSORNAME"/suricata.yaml >> $LOG 2>&1
+
+	# Grab MTU for interface(s) and add 24 to snaplen for VLAN-tagging, etc
+        MTU=`cat /sys/class/net/$INTERFACE/mtu`
+        MTU_FIN=`echo $(($MTU+24))`
+
+        # Write IDS config to files
 	sed -i "s|# config snaplen:|config snaplen: $MTU_FIN|g" /etc/nsm/"$SENSORNAME"/snort.conf
 	sed -i "s|^ipvar HOME_NET.*|ipvar HOME_NET \[$HOME_NET\]|g" /etc/nsm/"$SENSORNAME"/snort.conf
 	sed -i "s|classification-file: /etc/suricata/classification.config|classification-file: /etc/nsm/$SENSORNAME/classification.config|g" /etc/nsm/"$SENSORNAME"/suricata.yaml

--- a/bin/sosetup-network
+++ b/bin/sosetup-network
@@ -443,6 +443,7 @@ iface $INTERFACE inet manual
   post-up ethtool -G \$IFACE rx $MAX_RX; for i in rx tx sg tso ufo gso gro lro; do ethtool -K \$IFACE \$i off; done
   post-up echo 1 > /proc/sys/net/ipv6/conf/\$IFACE/disable_ipv6
   mtu $MTU
+
 EOF
 
 done


### PR DESCRIPTION
Fixes MTU for when user has not run sosetup-network after most recent updates, but has run sosetup.

Previously, MTU would be set as "0" (+16), if user updated and ran sosetup without re-running sosetup-network.

Thanks,
Wes