### PR TITLE
add IP to OSSEC AR whitelist for analyst

### DIFF
--- a/bin/so-allow
+++ b/bin/so-allow
@@ -102,6 +102,10 @@ echo "Here's the firewall rule we're about to add:"
 rule="sudo ufw allow $proto from $address to any port $port"
 echo $rule
 echo
+if [ $device == "analyst" ]; then
+        echo "We're also whitelisting $address in /var/ossec/etc/ossec.conf to prevent OSSEC Active Response from blocking it.  Keep in mind, the OSSEC server will be restarted once configuration is complete." 
+fi
+echo
 echo "To continue and add this rule, press Enter."
 echo "Otherwise, press Ctrl-c to exit."
 read input
@@ -115,3 +119,17 @@ echo "Rule has been added."
 echo
 echo "Here is the entire firewall ruleset:"
 ufw status
+echo
+if [ $device == "analyst" ]; then
+        if ! grep -q "<white_list>$address</white_list>" /var/ossec/etc/ossec.conf ; then
+                DATE=`date`
+                sed -i 's/<\/ossec_config>//' /var/ossec/etc/ossec.conf
+                sed -i '/^$/N;/^\n$/D' /var/ossec/etc/ossec.conf
+                echo -e "<!--Address $address added by /usr/sbin/so-allow on "$DATE"-->\n  <global>\n    <white_list>$address</white_list>\n  </global>\n</ossec_config>" >> /var/ossec/etc/ossec.conf
+                echo "Added whitelist entry for $address in /var/ossec/etc/ossec.conf."
+                echo
+                echo "Restarting OSSEC Server..."
+                service ossec-hids-server restart
+        fi
+fi
+echo

--- a/bin/so-disallow
+++ b/bin/so-disallow
@@ -102,6 +102,10 @@ echo "Here's the firewall rule we're about to remove:"
 rule="sudo ufw delete allow $proto from $address to any port $port"
 echo $rule
 echo
+if [ $device == "analyst" ]; then
+	echo "We're also removing $address from OSSEC's Active Response whitelist in /var/ossec/etc/ossec.conf."
+fi
+echo
 echo "To continue and remove this rule, press Enter."
 echo "Otherwise, press Ctrl-c to exit."
 read input
@@ -110,8 +114,16 @@ read input
 # Run the command to add the firewall rule
 #########################################
 $rule
-
 echo "Rule has been removed."
 echo
 echo "Here is the entire firewall ruleset:"
 ufw status
+if grep -q "Address $address" /var/ossec/etc/ossec.conf; then
+	sed -i "/Address $address/,+3d" /var/ossec/etc/ossec.conf
+	sed -i '/^$/N;/^\n$/D' /var/ossec/etc/ossec.conf
+        echo "Restarting OSSEC Server..."
+        service ossec-hids-server restart
+        echo
+        echo "$address has been removed from OSSEC's Active Response whitelist in /var/ossec/etc/ossec.conf."
+        echo
+fi


### PR DESCRIPTION
Add IP for analyst to OSSEC AR whitelist in /var/ossec/etc/ossec.conf for so-allow and remove IP when removing analyst using so-disallow.

https://github.com/Security-Onion-Solutions/security-onion/issues/1111