### PR TITLE
Do not allocate 9200, 9300, or 9600 to snort_agent

### DIFF
--- a/bin/sosetup
+++ b/bin/sosetup
@@ -1328,6 +1328,11 @@ for INTERFACE in $ALL_INTERFACES; do
 	# Increment the Barnyard2 port number by 100
 	let BY2PORT=BY2PORT+100
 
+	# Skip over 9200 and 9300 as Elasticsearch uses these
+	if [ "$BY2PORT" == "9200" ]; then
+		let BY2PORT=9400
+	fi
+
         # Copy our customized snort.conf (and associated files) into place
         cp /etc/nsm/templates/snort/attribute_table.dtd /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1
         cp /etc/nsm/templates/snort/snort.conf /etc/nsm/"$SENSORNAME"/ >> $LOG 2>&1

--- a/bin/sosetup
+++ b/bin/sosetup
@@ -1328,9 +1328,9 @@ for INTERFACE in $ALL_INTERFACES; do
 	# Increment the Barnyard2 port number by 100
 	let BY2PORT=BY2PORT+100
 
-	# Skip over 9200 and 9300 as Elasticsearch uses these
+	# Skip over 9200-9600 as Elasticsearch uses 9200 & 9300 and Logstash uses 9600.
 	if [ "$BY2PORT" == "9200" ]; then
-		let BY2PORT=9400
+		let BY2PORT=9700
 	fi
 
         # Copy our customized snort.conf (and associated files) into place


### PR DESCRIPTION
so-elasticsearch needs 9200 and 9300, and so-logstash needs 9600.  These will fail to start if those ports are taken by snort_agent.tcl.