### PR TITLE
rename ELSA to Kibana and add deprecation notice(s)

### DIFF
--- a/share/securityonion/sosetup-forward.conf
+++ b/share/securityonion/sosetup-forward.conf
@@ -76,13 +76,13 @@ SGUIL_SERVER_NAME='securityonion'
 
 # SGUIL_CLIENT_USERNAME
 # If SERVER=1, then this is the username that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # Please use alphanumeric characters only!
 SGUIL_CLIENT_USERNAME='onionuser'
 
 # SGUIL_CLIENT_PASSWORD_1
 # If SERVER=1, then this is the password that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # If you set a password here, you may want to change it later and/or
 # shred this file.
 SGUIL_CLIENT_PASSWORD_1='asdfasdf'
@@ -163,7 +163,7 @@ SNORT_AGENT_ENABLED='yes'
 # BARNYARD2_ENABLED
 # Do you want to run Barnyard2?  yes/no
 # Barnyard2 sends IDS alerts from Snort/Suricata to
-# Sguil's Snort agent and syslog (ELSA).
+# Sguil's Snort agent and syslog (Kibana).
 BARNYARD2_ENABLED='yes'
 
 # PCAP_ENABLED
@@ -175,6 +175,7 @@ PCAP_ENABLED='yes'
 # The pcap_agent allows Sguil to access the pcap store.
 PCAP_AGENT_ENABLED='yes'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PRADS_ENABLED
 # Do you want to run Prads?  yes/no
 # Prads writes session data and asset data.
@@ -182,22 +183,26 @@ PCAP_AGENT_ENABLED='yes'
 # folks don't run Prads.
 PRADS_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # SANCP_AGENT_ENABLED
 # Do you want to run the sancp_agent?  yes/no
 # sancp_agent sends session data from Prads to Sguil.
 SANCP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PADS_AGENT_ENABLED
 # Do you want to run the pads_agent?  yes/no
 # pads_agent sends asset data from Prads to Sguil.
 PADS_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # HTTP_AGENT_ENABLED
 # Do you want to run the http_agent?  yes/no
 # http_agent sends http logs from Bro to Sguil.
 # If you're running ELSA, then you probably want to disable this.
 HTTP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # ARGUS_ENABLED
 # Do you want to run Argus?  yes/no
 # Argus writes session data, also provided by Bro and Prads.

--- a/share/securityonion/sosetup-master.conf
+++ b/share/securityonion/sosetup-master.conf
@@ -76,13 +76,13 @@ SGUIL_SERVER_NAME='securityonion'
 
 # SGUIL_CLIENT_USERNAME
 # If SERVER=1, then this is the username that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # Please use alphanumeric characters only!
 SGUIL_CLIENT_USERNAME='onionuser'
 
 # SGUIL_CLIENT_PASSWORD_1
 # If SERVER=1, then this is the password that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # If you set a password here, you may want to change it later and/or
 # shred this file.
 SGUIL_CLIENT_PASSWORD_1='asdfasdf'
@@ -163,7 +163,7 @@ SNORT_AGENT_ENABLED='yes'
 # BARNYARD2_ENABLED
 # Do you want to run Barnyard2?  yes/no
 # Barnyard2 sends IDS alerts from Snort/Suricata to
-# Sguil's Snort agent and syslog (ELSA).
+# Sguil's Snort agent and syslog (Kibana).
 BARNYARD2_ENABLED='yes'
 
 # PCAP_ENABLED
@@ -175,6 +175,7 @@ PCAP_ENABLED='yes'
 # The pcap_agent allows Sguil to access the pcap store.
 PCAP_AGENT_ENABLED='yes'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PRADS_ENABLED
 # Do you want to run Prads?  yes/no
 # Prads writes session data and asset data.
@@ -182,22 +183,26 @@ PCAP_AGENT_ENABLED='yes'
 # folks don't run Prads.
 PRADS_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # SANCP_AGENT_ENABLED
 # Do you want to run the sancp_agent?  yes/no
 # sancp_agent sends session data from Prads to Sguil.
 SANCP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PADS_AGENT_ENABLED
 # Do you want to run the pads_agent?  yes/no
 # pads_agent sends asset data from Prads to Sguil.
 PADS_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # HTTP_AGENT_ENABLED
 # Do you want to run the http_agent?  yes/no
 # http_agent sends http logs from Bro to Sguil.
 # If you're running ELSA, then you probably want to disable this.
 HTTP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # ARGUS_ENABLED
 # Do you want to run Argus?  yes/no
 # Argus writes session data, also provided by Bro and Prads.

--- a/share/securityonion/sosetup-storage.conf
+++ b/share/securityonion/sosetup-storage.conf
@@ -76,13 +76,13 @@ SGUIL_SERVER_NAME='securityonion'
 
 # SGUIL_CLIENT_USERNAME
 # If SERVER=1, then this is the username that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # Please use alphanumeric characters only!
 SGUIL_CLIENT_USERNAME='onionuser'
 
 # SGUIL_CLIENT_PASSWORD_1
 # If SERVER=1, then this is the password that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # If you set a password here, you may want to change it later and/or
 # shred this file.
 SGUIL_CLIENT_PASSWORD_1='asdfasdf'
@@ -163,7 +163,7 @@ SNORT_AGENT_ENABLED='no'
 # BARNYARD2_ENABLED
 # Do you want to run Barnyard2?  yes/no
 # Barnyard2 sends IDS alerts from Snort/Suricata to
-# Sguil's Snort agent and syslog (ELSA).
+# Sguil's Snort agent and syslog (Kibana).
 BARNYARD2_ENABLED='no'
 
 # PCAP_ENABLED
@@ -175,6 +175,7 @@ PCAP_ENABLED='no'
 # The pcap_agent allows Sguil to access the pcap store.
 PCAP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PRADS_ENABLED
 # Do you want to run Prads?  yes/no
 # Prads writes session data and asset data.
@@ -182,22 +183,26 @@ PCAP_AGENT_ENABLED='no'
 # folks don't run Prads.
 PRADS_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # SANCP_AGENT_ENABLED
 # Do you want to run the sancp_agent?  yes/no
 # sancp_agent sends session data from Prads to Sguil.
 SANCP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PADS_AGENT_ENABLED
 # Do you want to run the pads_agent?  yes/no
 # pads_agent sends asset data from Prads to Sguil.
 PADS_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # HTTP_AGENT_ENABLED
 # Do you want to run the http_agent?  yes/no
 # http_agent sends http logs from Bro to Sguil.
 # If you're running ELSA, then you probably want to disable this.
 HTTP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # ARGUS_ENABLED
 # Do you want to run Argus?  yes/no
 # Argus writes session data, also provided by Bro and Prads.

--- a/share/securityonion/sosetup.conf
+++ b/share/securityonion/sosetup.conf
@@ -76,13 +76,13 @@ SGUIL_SERVER_NAME='securityonion'
 
 # SGUIL_CLIENT_USERNAME
 # If SERVER=1, then this is the username that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # Please use alphanumeric characters only!
 SGUIL_CLIENT_USERNAME='onionuser'
 
 # SGUIL_CLIENT_PASSWORD_1
 # If SERVER=1, then this is the password that we'll create
-# for Sguil/Squert/ELSA.
+# for Sguil/Squert/Kibana.
 # If you set a password here, you may want to change it later and/or
 # shred this file.
 SGUIL_CLIENT_PASSWORD_1='asdfasdf'
@@ -163,7 +163,7 @@ SNORT_AGENT_ENABLED='yes'
 # BARNYARD2_ENABLED
 # Do you want to run Barnyard2?  yes/no
 # Barnyard2 sends IDS alerts from Snort/Suricata to
-# Sguil's Snort agent and syslog (ELSA).
+# Sguil's Snort agent and syslog (Kibana).
 BARNYARD2_ENABLED='yes'
 
 # PCAP_ENABLED
@@ -175,6 +175,7 @@ PCAP_ENABLED='yes'
 # The pcap_agent allows Sguil to access the pcap store.
 PCAP_AGENT_ENABLED='yes'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PRADS_ENABLED
 # Do you want to run Prads?  yes/no
 # Prads writes session data and asset data.
@@ -182,22 +183,26 @@ PCAP_AGENT_ENABLED='yes'
 # folks don't run Prads.
 PRADS_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # SANCP_AGENT_ENABLED
 # Do you want to run the sancp_agent?  yes/no
 # sancp_agent sends session data from Prads to Sguil.
 SANCP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # PADS_AGENT_ENABLED
 # Do you want to run the pads_agent?  yes/no
 # pads_agent sends asset data from Prads to Sguil.
 PADS_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # HTTP_AGENT_ENABLED
 # Do you want to run the http_agent?  yes/no
 # http_agent sends http logs from Bro to Sguil.
 # If you're running ELSA, then you probably want to disable this.
 HTTP_AGENT_ENABLED='no'
 
+##!! THIS OPTION IS DEPRECATED AND IS NO LONGER USED - DO NOT ALTER OR REMOVE
 # ARGUS_ENABLED
 # Do you want to run Argus?  yes/no
 # Argus writes session data, also provided by Bro and Prads.


### PR DESCRIPTION
- rename ELSA to Kibana in setup conf files
- add deprecation notice for options that are no longer supported