### PR TITLE
Fixed bug where the regex in sed disables incorrect interfaces, ie. e…

### DIFF
--- a/bin/sosetup
+++ b/bin/sosetup
@@ -1432,7 +1432,7 @@ for INTERFACE in $ALL_INTERFACES; do
 		echo "Leaving $INTERFACE as-is (enabled)." >> $LOG 2>&1
 	else
 		echo "$INTERFACE not found in selected interfaces.  Disabling." >> $LOG 2>&1
-		sed -i "s|^$HOSTNAME-$INTERFACE|#$HOSTNAME-$INTERFACE|g" /etc/nsm/sensortab
+		sed -i "s|\<$HOSTNAME-$INTERFACE\>|#$HOSTNAME-$INTERFACE|g" /etc/nsm/sensortab
 	fi
 done
 


### PR DESCRIPTION
…no4 and eno49 will both be disabled.

Fixed bug in the sed regex where it will disable incorrect interfaces, i.e. it will disable 'eno4' and 'eno49'.

Fixed bug in regex used in sed, which would comment out unintended network interfaces, i.e. it should comment out 'eno4' but it will also comment out 'eno49'.