### PR TITLE
do not write interfaces if we lack valid contents

### DIFF
--- a/bin/sosetup-network
+++ b/bin/sosetup-network
@@ -366,6 +366,12 @@ function CONFIGURE_NETWORK() {
 # Create the log directory
 mkdir -p $LOGDIR
 
+# make sure we have data
+if [ -z "$MGMT_CONFIG_TYPE" -a -z "$ADDRESS" ]; then
+	echo "ERROR: unable to configure network"
+	exit
+fi
+
 # Change hostname if necessary
 if [ "$HOSTNAME" != "$NEWHOSTNAME" ]; then
 	sed -i "s|$HOSTNAME|$NEWHOSTNAME|" /etc/hosts


### PR DESCRIPTION
This checks to make sure both mgmt type and address aren't empty.  If it's DHCP, the type variable should be set to that, and if not, then we at least need an address to write to the interfaces file.

This should prevent cases where I configure the network myself, but forget to put "Security Onion" somewhere in it, so when I run sosetup with the -f flag, it clobbers my interfaces file instead of running in the app settings I intend.

Another option might be to avoid calling sosetup-network entirely if sosetup is given a -f flag.  If someone is using a setup file, it should be safe to assume they are capable enough to configure the network interfaces themselves.